### PR TITLE
Django: Better Error Handling for Rest Endpoints

### DIFF
--- a/src/django-app/django-project/config/settings.py
+++ b/src/django-app/django-project/config/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "drf_standardized_errors",
     "djoser",
     "phonenumber_field",
     "accounts.apps.AccountsConfig",
@@ -134,8 +135,10 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
-    "EXCEPTION_HANDLER": "rest_framework.views.exception_handler",
+    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
 }
+
+DRF_STANDARDIZED_ERRORS = {"ENABLE_IN_DEBUG_FOR_UNHANDLED_EXCEPTIONS": True}
 
 SIMPLE_JWT = {
     "AUTH_HEADER_TYPES": ("JWT",),

--- a/src/django-app/requirements.txt
+++ b/src/django-app/requirements.txt
@@ -14,6 +14,7 @@ django-templated-mail==1.1.1
 djangorestframework==3.14.0
 djangorestframework-simplejwt==4.8.0
 djoser==2.1.0
+drf-standardized-errors==0.12.3
 idna==3.4
 itypes==1.2.0
 Jinja2==3.1.2


### PR DESCRIPTION
### Better Error Handling for Rest Endpoints.
This PR adds [drf-standardized-errors](https://github.com/ghazi-git/drf-standardized-errors) to enhance how errors are sent back to the API caller.

This closes #57.