### PR TITLE
Backend: Quote Request Endpoints

### DIFF
--- a/src/django-app/quotes/policies.py
+++ b/src/django-app/quotes/policies.py
@@ -92,7 +92,7 @@ class QuoteRequestAccessPolicy(AccessPolicy):
             "condition_expression": ["(is_shop_related or is_owner)"],
         },
         {
-            "action": ["create"],
+            "action": ["create", "bulk_create"],
             "principal": "authenticated",
             "effect": "allow",
             "condition": ["is_customer"],

--- a/src/django-app/quotes/serializers.py
+++ b/src/django-app/quotes/serializers.py
@@ -70,6 +70,8 @@ class QuoteRequestWriteSerializer(serializers.ModelSerializer):
             max_length=1000000, allow_empty_file=False, use_url=False
         ),
         write_only=True,
+        allow_null=True,
+        default=[],
     )
 
     class Meta:
@@ -86,13 +88,17 @@ class QuoteRequestWriteSerializer(serializers.ModelSerializer):
             "vehicle",
         )
         read_only_fields = ("id",)
-        extra_kwargs = {"customer": {"source": "user"}}
+        extra_kwargs = {
+            "customer": {"source": "user"},
+            "uploaded_images": {"required": False},
+        }
 
     def create(self, validated_data):
-        uploaded_images = validated_data.pop("uploaded_images")
+        uploaded_images = validated_data.pop("uploaded_images", None)
         quote_request = QuoteRequest.objects.create(**validated_data)
-        for image in uploaded_images:
-            QR_image = ImageQuote.objects.create(
-                quote_request=quote_request, photo=image
-            )
+        if uploaded_images is not None:
+            for image in uploaded_images:
+                QR_image = ImageQuote.objects.create(
+                    quote_request=quote_request, photo=image
+                )
         return quote_request

--- a/src/django-app/quotes/views.py
+++ b/src/django-app/quotes/views.py
@@ -1,6 +1,14 @@
 from django.shortcuts import render
+from django.db import transaction
+from django.core.exceptions import ValidationError
 from rest_framework import viewsets
+from rest_framework import status
+from rest_framework.response import Response
 from rest_access_policy import AccessViewSetMixin
+from rest_framework.decorators import action
+from copy import deepcopy
+import traceback
+import logging
 
 from .serializers import (
     QuoteRequestSerializer,
@@ -10,6 +18,7 @@ from .serializers import (
 )
 from .models import Quote, QuoteRequest
 from .policies import QuoteAccessPolicy, QuoteRequestAccessPolicy
+from vehicles.models import Vehicle
 
 
 class QuoteViewSet(AccessViewSetMixin, viewsets.ModelViewSet):
@@ -36,3 +45,55 @@ class QuoteRequestViewSet(AccessViewSetMixin, viewsets.ModelViewSet):
         if self.action in ["create", "update", "partial_update"]:
             return QuoteRequestWriteSerializer
         return QuoteRequestSerializer
+
+    @action(detail=False, methods=["post"])
+    def bulk_create(self, request, *args, **kwargs):
+        try:
+            with transaction.atomic():
+                quote_request = request.data
+
+                vehicle_vin = quote_request.pop("vehicle_vin", None)
+                vehicle_make = quote_request.pop("vehicle_make", None)
+                vehicle_model = quote_request.pop("vehicle_model", None)
+                vehicle_year = quote_request.pop("vehicle_year", None)
+                vehicle, created = Vehicle.objects.get_or_create(
+                    vin=vehicle_vin,
+                    manufacturer=vehicle_make,
+                    model=vehicle_model,
+                    year=vehicle_year,
+                    customer=request.user,
+                )
+                quote_request["vehicle"] = vehicle.pk
+
+                shop_ids = quote_request.pop("shops", [])
+                quote_requests = []
+                for shop_id in shop_ids:
+                    qr = deepcopy(quote_request)
+                    qr["shop"] = shop_id
+                    quote_requests.append(qr)
+
+                serializer = QuoteRequestWriteSerializer(
+                    data=quote_requests, many=True, context={"request": request}
+                )
+                serializer.is_valid(raise_exception=True)
+
+                validated_data = serializer.validated_data
+                for data in validated_data:
+                    del data["uploaded_images"]
+                quote_requests = [
+                    QuoteRequest(**data, user=request.user) for data in validated_data
+                ]
+
+                QuoteRequest.objects.bulk_create(quote_requests)
+                return Response(
+                    {"message": f"{len(quote_requests)} quote requests created."},
+                    status=status.HTTP_201_CREATED,
+                )
+        except Exception as err:
+            logging.error(traceback.format_exc())
+            return Response(
+                {
+                    "status": False,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )


### PR DESCRIPTION
This PR adds a Quote Request endpoint for creating quote requests in bulk.

An example of a request looks like:
```
{
  "shops": [1,3,4],
  "description": "Issue with battery",
  "vehicle_vin": "12345",
  "vehicle_make": "Tesla",
  "vehicle_model": "Model XYZ",
  "vehicle_year": "2022"
}
```

API URL: [/quotes/quote-requests/bulk_create/](http://127.0.0.1:8000/docs/#/quotes/quotes_quote_requests_bulk_create_create)

Note: I have not tested this with uploading images, but I am skipping it for now (for the demo).