### PR TITLE
Shows newly created services in GET request

### DIFF
--- a/src/django-app/shops/policies.py
+++ b/src/django-app/shops/policies.py
@@ -175,7 +175,7 @@ class ServiceAccessPolicy(AccessPolicy):
             elif request.user.type == "employee":
                 employee_shop = EmployeeData.objects.get(user=request.user).shop
                 return qs.filter(shop=employee_shop)
-        return qs
+        return qs.filter()
 
     def user_type_is_shop_owner(self, request, view, action):
         return request.user.type == "shop_owner"


### PR DESCRIPTION
Fixed issue where newly created services were not showing when customer sent GET to /shops/services/