### PR TITLE
Fix images not accessible from Digital Oceans

### DIFF
--- a/src/django-app/config/settings.py
+++ b/src/django-app/config/settings.py
@@ -214,7 +214,7 @@ STATIC_ROOT = Path(BASE_DIR).joinpath("staticfiles")
 STATICFILES_DIRS = (Path(BASE_DIR).joinpath("static"),)
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
-MEDIA_URL = "/media/"
+MEDIA_URL = "media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 # Default primary key field type


### PR DESCRIPTION
@tevisdoe The Images work locally. It seems like there is an issue with Digital Oceans. This fix is based on this: https://stackoverflow.com/a/54361263

But don't think this will work. Let me know if you think we should merge this?